### PR TITLE
Update isir-viewer.html to include FC as valid state code

### DIFF
--- a/isir-viewer.html
+++ b/isir-viewer.html
@@ -1224,6 +1224,7 @@ export const valid_state_codes = {
   'CT': 1, // Connecticut
   'DE': 1, // Delaware
   'DC': 1, // District of Columbia
+  'FC': 1, // Foreign Country ?
   'FM': 1, // Federated States of Micronesia
   'FL': 1, // Florida
   'GA': 1, // Georgia


### PR DESCRIPTION
Record 15 of the new system generated test isirs (IDSA25OP-20240301.txt) fails with an invalid state code of FC. Assuming FC stands for Foreign Country.

Field f_36 State failed for "FC"