### PR TITLE
Update isir-viewer.html for field 581

### DIFF
--- a/isir-viewer.html
+++ b/isir-viewer.html
@@ -8094,7 +8094,7 @@ export const field_580 = {len: 1, pos_start: 4081, pos_end: 4082,
 
 export const field_581 = {len: 5, pos_start: 4082, pos_end: 4087,
     idx: 581, name: "Use User Provided Data Only", path: ["Use_User_Provided_Data_Only"], 
-    validate: _validate_options, empty: "False",
+    validate: _validate_options, allow_blank: true,
     options: [
       {op: "enum", options: {
         "True": "True",


### PR DESCRIPTION
Record 1 of the new system generated test isirs (IDSA25OP-20240301.txt) fails on field 581.

Field f_581 Use User Provided Data Only failed for " " 

Record 1 also fails on fields 861 and 942, but allow_blank doesn't seem to work with those fields.
Field f_861 (filler) failed for " "
Field f_942 (filler) failed for " "