### PR TITLE
Update isir-viewer.html _validate_fixed_decimal

### DIFF
--- a/isir-viewer.html
+++ b/isir-viewer.html
@@ -862,7 +862,12 @@ function _check_date(sz) {
 }
 const _validate_date = (sz_value, field) => _validate_options(sz_value, field) && _check_date(sz_value)
 const _validate_yearmonth = (sz_value, field) => _validate_options(sz_value, field) && _check_date(sz_value.length==6 ? sz_value+'01' : sz_value)
-const _validate_fixed_decimal = (sz_value) => /\d*/.test(sz_value)
+const _validate_fixed_decimal = (sz_value, field) => {
+    if(sz_value.trim() && sz_value.trim().length !== field.len) {
+        return false;
+    }
+    return /\d*/.test(sz_value)
+}
 
 const _rx_correction_highlight_verify_flags = /^(?<correction>[012])(?<highlight>[01])(?<verify>[012])$/
 const _validate_correction = (sz_value) => {


### PR DESCRIPTION
Field 638 Valid content is:
Numeric
Format is 99v99999
Blank
“v” is an implied decimal and is not included in the output. Example: 01.00000 is 0100.000%

Record 27 of the new system generated test isirs (IDSA25OP-20240301.txt) seems to have bad data in field 638: 55000  . 

Is this supposed to be 55.000 which is 5500% ? Seems like it should be 550% which would be 0550000 = 05.50000 = 550%

This change adds a check to _validate_fixed_decimal for valid length.