### PR TITLE
Updated isir-module.js and embeds from March 5th spec update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,17 @@ Initial release of project supporting ISIR Layout specification released today, 
 ### Test ISIRs Changes
 
 - Added a new system-generated test ISIR file to the [test-isir-files folder](/test-isir-files).
+
+
+## 2024-03-06
+
+### Code Changes
+
+- Updated `isir-module.js` from [2024-25 FAFSA Specification Guide (March 2024 Update #2)](https://fsapartners.ed.gov/knowledge-center/library/handbooks-manuals-or-guides/2023-05-31/2024-25-fafsa-specifications-guide-march-2024-update-2)
+    - Minimum for _Parent Contribution_ field 312 set to `-1500` (previously `0`)
+    - `Blank` removed as valid option from Student birthdate for field 29
+    - `Blank` added as valid option for field 518 _Use User Provided Data Only_
+    - `Blank` added as valid option for NSLDS Loan Change Flag fields 723, 746, 769, 792, 815, and 838
+    - `Blank` added as valid option for FTI fields 861, 881, and 942
+    - added `"FC"` to lookup for valid State Codes per header in Table 4-4 of the ISIR Layout specification guide.
+    - added `.raw` field value alongside trimmed `.value` to `isir_field_validate()` result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,10 @@ Initial release of project supporting ISIR Layout specification released today, 
 
 ### Code Changes
 
-- Updated `isir-module.js` from [2024-25 FAFSA Specification Guide (March 2024 Update #2)](https://fsapartners.ed.gov/knowledge-center/library/handbooks-manuals-or-guides/2023-05-31/2024-25-fafsa-specifications-guide-march-2024-update-2)
+- Updated `isir-module.js` from [2024-25 FAFSA Specification Guide (March 2024 Update #2)](https://fsapartners.ed.gov/knowledge-center/library/handbooks-manuals-or-guides/2023-05-31/2024-25-fafsa-specifications-guide-march-2024-update-2). These updates are also incorporated into `isir-viewer.html` and `isir-from-spreadsheet.html`.
     - Minimum for _Parent Contribution_ field 312 set to `-1500` (previously `0`)
     - `Blank` removed as valid option from Student birthdate for field 29
-    - `Blank` added as valid option for field 518 _Use User Provided Data Only_
+    - `Blank` added as valid option for field 581 _Use User Provided Data Only_
     - `Blank` added as valid option for NSLDS Loan Change Flag fields 723, 746, 769, 792, 815, and 838
     - `Blank` added as valid option for FTI fields 861, 881, and 942
     - added `"FC"` to lookup for valid State Codes per header in Table 4-4 of the ISIR Layout specification guide.

--- a/isir-from-spreadsheet.html
+++ b/isir-from-spreadsheet.html
@@ -174,7 +174,7 @@ export function as_isir_dat_blob_url(isir_frames, opt={isir_mode}) {
 
     } else if (/saig/.test(isir_mode)) {
         isir_headers.push(`O*N05TG99999       ,CLS=IDAP25OP,XXX,BAT=,`)
-        // Note: 2023-24 year had an extra blank line after the header
+        isir_headers.push('') // Note: 2023-24 year had an extra blank line after the header
         isir_footers.push(`O*N95TG99999       ,CLS=IDAP25OP,XXX,BAT=,`)
 
     } else if (!isir_mode || 'blank' == isir_mode) {
@@ -664,7 +664,7 @@ export function isir_field_read(field, isir_frame, mode) {
  * @returns {value: string, field: ISIRField, result?:*, invalid?:bool|string}
  */
 export function isir_field_validate(field, value, mode) {
-    let valid, res={__proto__: {field}, value}, issues=[]
+    let valid, res={__proto__: {field}, raw: value, value}, issues=[]
     value = `${value}`.trimEnd()
 
     // Detect left-padding spaces or zero issues. Spec change from prior years.
@@ -682,9 +682,13 @@ export function isir_field_validate(field, value, mode) {
         valid = field.validate?.(value, field)
     }
 
-    if (valid && 'object' == typeof valid) {
-        res.result = valid.result
-        valid = valid.valid ?? true
+    res.value = value
+    if (valid) {
+        res.result = value
+        if ('object' == typeof valid) {
+            res.result = valid.result
+            valid = valid.valid ?? true
+        }
     }
 
     if (false == valid)
@@ -962,7 +966,7 @@ function _init_isir_model() {
 // ISIR field validator logic implementations
 //
 
-const _validate_expect = (sz_value, field) => sz_value == field.expect
+const _validate_expect = (sz_value, field) => (sz_value == field.expect) || (field.allow_blank ? sz_value == '' : false)
 
 function _check_date(sz) {
     if ('' === sz) return;
@@ -1409,6 +1413,10 @@ export const valid_state_codes = {
   // Canada and Mexico state codes
   'CN': 1, // Canada
   'MX': 1, // Mexico
+
+  // FC for Foreign Country as State Code per table 4-4 
+  // of Volume 4, Record Layouts and Processing Codes
+  'FC': 1, // Foreign Country
 }
 const _validate_state_codes = (sz_value) => 1 === valid_state_codes[sz_value]
 
@@ -1864,8 +1872,7 @@ export const field_29 = {len: 8, pos_start: 337, pos_end: 345,
         " 09\t01-30",
         " 10\t01-31",
         " 11\t01-30",
-        " 12\t01-31",
-        "Blank"
+        " 12\t01-31"
     ]};
 
 export const field_30 = {len: 9, pos_start: 345, pos_end: 354,
@@ -5838,10 +5845,10 @@ export const field_312 = {len: 15, pos_start: 2955, pos_end: 2970,
     idx: 312, name: "Parent Contribution", alias: "PC", path: ["parent","Contribution"], 
     validate: _validate_options, allow_blank: true,
     options: [
-      {op: "range", "min":"0","max":"999999999999999"},
+      {op: "range", "min":"-1500","max":"999999999999999"},
     ],
     note: [
-        "0 to 999999999999999",
+        "-1500 to 999999999999999",
         "Blank"
     ]};
 
@@ -8206,7 +8213,7 @@ export const field_580 = {len: 1, pos_start: 4081, pos_end: 4082,
 
 export const field_581 = {len: 5, pos_start: 4082, pos_end: 4087,
     idx: 581, name: "Use User Provided Data Only", path: ["Use_User_Provided_Data_Only"], 
-    validate: _validate_options, empty: "False",
+    validate: _validate_options, allow_blank: true, empty: "False",
     options: [
       {op: "enum", options: {
         "True": "True",
@@ -8215,7 +8222,8 @@ export const field_581 = {len: 5, pos_start: 4082, pos_end: 4087,
     ],
     note: [
         "True",
-        "False"
+        "False",
+        "Blank"
     ]};
 
 export const field_582 = {len: 361, pos_start: 4087, pos_end: 4448,
@@ -10197,7 +10205,8 @@ export const field_723 = {len: 1, pos_start: 5126, pos_end: 5127,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_724 = {len: 2, pos_start: 5127, pos_end: 5129,
@@ -10538,7 +10547,8 @@ export const field_746 = {len: 1, pos_start: 5248, pos_end: 5249,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_747 = {len: 2, pos_start: 5249, pos_end: 5251,
@@ -10868,7 +10878,8 @@ export const field_769 = {len: 1, pos_start: 5370, pos_end: 5371,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_770 = {len: 2, pos_start: 5371, pos_end: 5373,
@@ -11199,7 +11210,8 @@ export const field_792 = {len: 1, pos_start: 5492, pos_end: 5493,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_793 = {len: 2, pos_start: 5493, pos_end: 5495,
@@ -11528,7 +11540,8 @@ export const field_815 = {len: 1, pos_start: 5614, pos_end: 5615,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_816 = {len: 2, pos_start: 5615, pos_end: 5617,
@@ -11857,7 +11870,8 @@ export const field_838 = {len: 1, pos_start: 5736, pos_end: 5737,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_839 = {len: 2, pos_start: 5737, pos_end: 5739,
@@ -12187,10 +12201,11 @@ export const field_860 = {len: 50, pos_start: 7035, pos_end: 7085,
 
 export const field_861 = {len: 11, pos_start: 7085, pos_end: 7096,
     idx: 861, name: null, 
-    validate: _validate_expect,
+    validate: _validate_expect, allow_blank: true,
     expect: "CUI//SP-TAX", non_content: true,
     note: [
-        "Exact string: “CUI//SP-TAX”"
+        "Exact string: “CUI//SP-TAX”",
+        "Blank"
     ]};
 
 export const field_862 = {len: 4, pos_start: 7096, pos_end: 7100,
@@ -12453,7 +12468,8 @@ export const field_881 = {len: 3, pos_start: 7206, pos_end: 7209,
         "203 = PII Match Failed",
         "206 = Partial Delivery of Content",
         "212 = Cannot Verify Return Data",
-        "214 = No Return on File"
+        "214 = No Return on File",
+        "Blank"
     ]};
 
 
@@ -13283,10 +13299,11 @@ export const field_941 = {len: 3, pos_start: 7545, pos_end: 7548,
 
 export const field_942 = {len: 11, pos_start: 7548, pos_end: 7559,
     idx: 942, name: null, 
-    validate: _validate_expect,
+    validate: _validate_expect, allow_blank: true,
     expect: "CUI//SP-TAX", non_content: true,
     note: [
-        "Exact string: “CUI//SP-TAX”"
+        "Exact string: “CUI//SP-TAX”",
+        "Blank"
     ]};
 
 export const field_943 = {len: 50, pos_start: 7559, pos_end: 7609,

--- a/isir-viewer.html
+++ b/isir-viewer.html
@@ -439,8 +439,12 @@ export function * iter_check_isirs_list(isir_list=window.isir_samples) {
 
         isir_module.isir_load_report(isir, {mode: isir_validation})
         if (0 != isir_validation.size) {
+            console.group('Issues for ISIR %o', n)
             for (let [field, res] of isir_validation.entries()) {
                 let counts = unique_warnings.get(field) || new Map()
+
+                if (field.name)
+                    console.log('Field %o "%s"', field.idx, field.name, res)
 
                 for (let key of res.issues)
                     counts.set(key, 1 + (counts.get(key) || 0))
@@ -448,6 +452,7 @@ export function * iter_check_isirs_list(isir_list=window.isir_samples) {
                 unique_warnings.set(field, counts)
             }
             isir_validation.clear() // reset incremental map
+            console.groupEnd()
         }
     }
     return unique_warnings
@@ -552,7 +557,7 @@ export function isir_field_read(field, isir_frame, mode) {
  * @returns {value: string, field: ISIRField, result?:*, invalid?:bool|string}
  */
 export function isir_field_validate(field, value, mode) {
-    let valid, res={__proto__: {field}, value}, issues=[]
+    let valid, res={__proto__: {field}, raw: value, value}, issues=[]
     value = `${value}`.trimEnd()
 
     // Detect left-padding spaces or zero issues. Spec change from prior years.
@@ -570,9 +575,13 @@ export function isir_field_validate(field, value, mode) {
         valid = field.validate?.(value, field)
     }
 
-    if (valid && 'object' == typeof valid) {
-        res.result = valid.result
-        valid = valid.valid ?? true
+    res.value = value
+    if (valid) {
+        res.result = value
+        if ('object' == typeof valid) {
+            res.result = valid.result
+            valid = valid.valid ?? true
+        }
     }
 
     if (false == valid)
@@ -850,7 +859,7 @@ function _init_isir_model() {
 // ISIR field validator logic implementations
 //
 
-const _validate_expect = (sz_value, field) => sz_value == field.expect
+const _validate_expect = (sz_value, field) => (sz_value == field.expect) || (field.allow_blank ? sz_value == '' : false)
 
 function _check_date(sz) {
     if ('' === sz) return;
@@ -1224,7 +1233,6 @@ export const valid_state_codes = {
   'CT': 1, // Connecticut
   'DE': 1, // Delaware
   'DC': 1, // District of Columbia
-  'FC': 1, // Foreign Country ?
   'FM': 1, // Federated States of Micronesia
   'FL': 1, // Florida
   'GA': 1, // Georgia
@@ -1298,6 +1306,10 @@ export const valid_state_codes = {
   // Canada and Mexico state codes
   'CN': 1, // Canada
   'MX': 1, // Mexico
+
+  // FC for Foreign Country as State Code per table 4-4 
+  // of Volume 4, Record Layouts and Processing Codes
+  'FC': 1, // Foreign Country
 }
 const _validate_state_codes = (sz_value) => 1 === valid_state_codes[sz_value]
 
@@ -1753,8 +1765,7 @@ export const field_29 = {len: 8, pos_start: 337, pos_end: 345,
         " 09\t01-30",
         " 10\t01-31",
         " 11\t01-30",
-        " 12\t01-31",
-        "Blank"
+        " 12\t01-31"
     ]};
 
 export const field_30 = {len: 9, pos_start: 345, pos_end: 354,
@@ -5727,10 +5738,10 @@ export const field_312 = {len: 15, pos_start: 2955, pos_end: 2970,
     idx: 312, name: "Parent Contribution", alias: "PC", path: ["parent","Contribution"], 
     validate: _validate_options, allow_blank: true,
     options: [
-      {op: "range", "min":"0","max":"999999999999999"},
+      {op: "range", "min":"-1500","max":"999999999999999"},
     ],
     note: [
-        "0 to 999999999999999",
+        "-1500 to 999999999999999",
         "Blank"
     ]};
 
@@ -8095,7 +8106,7 @@ export const field_580 = {len: 1, pos_start: 4081, pos_end: 4082,
 
 export const field_581 = {len: 5, pos_start: 4082, pos_end: 4087,
     idx: 581, name: "Use User Provided Data Only", path: ["Use_User_Provided_Data_Only"], 
-    validate: _validate_options, empty: "False",
+    validate: _validate_options, allow_blank: true, empty: "False",
     options: [
       {op: "enum", options: {
         "True": "True",
@@ -8104,7 +8115,8 @@ export const field_581 = {len: 5, pos_start: 4082, pos_end: 4087,
     ],
     note: [
         "True",
-        "False"
+        "False",
+        "Blank"
     ]};
 
 export const field_582 = {len: 361, pos_start: 4087, pos_end: 4448,
@@ -10086,7 +10098,8 @@ export const field_723 = {len: 1, pos_start: 5126, pos_end: 5127,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_724 = {len: 2, pos_start: 5127, pos_end: 5129,
@@ -10427,7 +10440,8 @@ export const field_746 = {len: 1, pos_start: 5248, pos_end: 5249,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_747 = {len: 2, pos_start: 5249, pos_end: 5251,
@@ -10757,7 +10771,8 @@ export const field_769 = {len: 1, pos_start: 5370, pos_end: 5371,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_770 = {len: 2, pos_start: 5371, pos_end: 5373,
@@ -11088,7 +11103,8 @@ export const field_792 = {len: 1, pos_start: 5492, pos_end: 5493,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_793 = {len: 2, pos_start: 5493, pos_end: 5495,
@@ -11417,7 +11433,8 @@ export const field_815 = {len: 1, pos_start: 5614, pos_end: 5615,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_816 = {len: 2, pos_start: 5615, pos_end: 5617,
@@ -11746,7 +11763,8 @@ export const field_838 = {len: 1, pos_start: 5736, pos_end: 5737,
     ],
     note: [
         "# = Changed",
-        "N = Did not change"
+        "N = Did not change",
+        "Blank"
     ]};
 
 export const field_839 = {len: 2, pos_start: 5737, pos_end: 5739,
@@ -12076,10 +12094,11 @@ export const field_860 = {len: 50, pos_start: 7035, pos_end: 7085,
 
 export const field_861 = {len: 11, pos_start: 7085, pos_end: 7096,
     idx: 861, name: null, 
-    validate: _validate_expect,
+    validate: _validate_expect, allow_blank: true,
     expect: "CUI//SP-TAX", non_content: true,
     note: [
-        "Exact string: “CUI//SP-TAX”"
+        "Exact string: “CUI//SP-TAX”",
+        "Blank"
     ]};
 
 export const field_862 = {len: 4, pos_start: 7096, pos_end: 7100,
@@ -12342,7 +12361,8 @@ export const field_881 = {len: 3, pos_start: 7206, pos_end: 7209,
         "203 = PII Match Failed",
         "206 = Partial Delivery of Content",
         "212 = Cannot Verify Return Data",
-        "214 = No Return on File"
+        "214 = No Return on File",
+        "Blank"
     ]};
 
 
@@ -13172,10 +13192,11 @@ export const field_941 = {len: 3, pos_start: 7545, pos_end: 7548,
 
 export const field_942 = {len: 11, pos_start: 7548, pos_end: 7559,
     idx: 942, name: null, 
-    validate: _validate_expect,
+    validate: _validate_expect, allow_blank: true,
     expect: "CUI//SP-TAX", non_content: true,
     note: [
-        "Exact string: “CUI//SP-TAX”"
+        "Exact string: “CUI//SP-TAX”",
+        "Blank"
     ]};
 
 export const field_943 = {len: 50, pos_start: 7559, pos_end: 7609,


### PR DESCRIPTION
### Code Changes

Updated `isir-module.js` from [2024-25 FAFSA Specification Guide (March 2024 Update #2)](https://fsapartners.ed.gov/knowledge-center/library/handbooks-manuals-or-guides/2023-05-31/2024-25-fafsa-specifications-guide-march-2024-update-2). These updates are also incorporated into `isir-viewer.html` and `isir-from-spreadsheet.html`.

- Minimum for _Parent Contribution_ field 312 set to `-1500` (previously `0`)
- `Blank` removed as valid option from Student birthdate for field 29
- `Blank` added as valid option for field 581 _Use User Provided Data Only_
- `Blank` added as valid option for NSLDS Loan Change Flag fields 723, 746, 769, 792, 815, and 838
- `Blank` added as valid option for FTI fields 861, 881, and 942
- added `"FC"` to lookup for valid State Codes per header in Table 4-4 of the ISIR Layout specification guide.
- added `.raw` field value alongside trimmed `.value` to `isir_field_validate()` result